### PR TITLE
Add Google logo and contact info

### DIFF
--- a/public/partnerLogos/google.svg
+++ b/public/partnerLogos/google.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 120">
+  <text x="0" y="90" font-family="Arial, Helvetica, sans-serif" font-size="90" font-weight="bold">
+    <tspan fill="#4285F4">G</tspan>
+    <tspan fill="#DB4437">o</tspan>
+    <tspan fill="#F4B400">o</tspan>
+    <tspan fill="#4285F4">g</tspan>
+    <tspan fill="#0F9D58">l</tspan>
+    <tspan fill="#DB4437">e</tspan>
+  </text>
+</svg>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,5 +1,5 @@
 ---
-let { theme = "blue", gradient = false, background = 'blue' } = Astro.props;
+let { theme = "blue", gradient = false, background = 'blue', phone } = Astro.props;
 let textColor, bgColor, logoColor, iconColor;
 if (theme == 'blue'){
     textColor = 'text-white';
@@ -37,6 +37,9 @@ const today = new Date();
             </a>
             
             <p class={`${textColor} py-2`}>Security From Zero to Trust</p>
+            {phone && (
+              <p class={`${textColor} py-1 font-semibold`}>{phone}</p>
+            )}
         </div>
             <ul class="grid grid-cols-2 gap-4 mb:gap-2 p-2 m-0 text-right">
                 <a href="#" id="footerRequestDemo" class={`${textColor} no-underline hover:underline cursor-pointer`}>Request Demo</a>

--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -24,6 +24,7 @@ const {
   blueGradient = false,
   solidBlue = false,
   backgroundColorScript = false,
+  phone,
 } = Astro.props;
 
 import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
@@ -72,7 +73,7 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
   <main class="flex-grow content">
     <slot />
   </main>
-  <Footer theme={footerBackground} gradient={footerLogoGradient} />
+  <Footer theme={footerBackground} gradient={footerLogoGradient} phone={phone} />
 </body>
 </html>
 

--- a/src/data/pages.json
+++ b/src/data/pages.json
@@ -684,6 +684,7 @@
 { "label": "Natuv", "iconSrc": "/partnerLogos/natuv.png", "alt": "Natuv", "href": "https://www.natuv.com", "scale": "0.9"},
 { "label": "Norseman", "iconSrc": "/partnerLogos/norseman.png", "alt": "Norseman", "href": "https://www.norseman.com", "scale": "0.9"},
 { "label": "Sourcefly", "iconSrc": "/partnerLogos/sourcefly.webp", "alt": "Sourcefly", "href": "https://www.sourcefly.com", "scale": "1"}
+{ "label": "Google", "iconSrc": "/partnerLogos/google.svg", "alt": "Google", "href": "https://www.google.com", "scale": "1"}
 ],
 "teamMembers": [
     { "name": "Chris Romeo", "title": "Chief Executive Officer", "imageSrc": "/profiles/chris-romeo.jpg", "bio": "Chris Romeo, a Co-Founder and the Chief Executive Officer of OneTier. He is an experienced Sales executive with over 20 years in Sales. He has previous Sales leadership roles at Atlantis Computing, Insight Engines, NICE, Kyriba and Dispersive." },

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -93,7 +93,7 @@ if (closestEvent) {
 //exportAllPostsAsJson(); 
 ---
 
-<Layout homeBackground='true' gradient="true" backgroundColorScript="true" navWidth={70} metadata={metadata}>
+<Layout homeBackground='true' gradient="true" backgroundColorScript="true" navWidth={70} metadata={metadata} phone="1 (844) 476-9757">
   <ParticlesBackground />
   <div class="mb:hidden">
     <DottedPathSVG


### PR DESCRIPTION
## Summary
- include Google logo for Partner page carousel
- add optional phone prop to `Layout` and `Footer` components
- display toll‑free number on the Home page footer

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877ecf5672c8321bbd8009cec34e2b9